### PR TITLE
add release drafter by default

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,4 @@
+template: |
+  ## What’s Changed
+
+  $CHANGES

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,23 @@
+#
+# Copyright The Titan Project Contributors.
+#
+
+#
+# We use release drafter to keep the in-progress release notes up to date:
+#
+#   https://github.com/marketplace/actions/release-drafter
+#
+name: Draft Release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update_draft_release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: toolmantim/release-drafter@v5.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # OS Generated files
 .DS_Store
+
+# Temporary files
+.*.swp


### PR DESCRIPTION
## Proposed Changes

We should use release drafter by default on all our repos. Since I forgot to do this correctly, I figured I might as well add it to our template repo.
